### PR TITLE
Use mktemp instead of tmp-repo for the temporary repo - also allow a repo definition to override this behavior if needed.

### DIFF
--- a/report.sh
+++ b/report.sh
@@ -4,7 +4,7 @@
 
 
 #directory to which we will checkout git repos and do magic.
-REPO_DIR="tmp-repo"
+REPO_DIR=${REPO_DIR:-$(mktemp -d)}
 INIT_DIR="`pwd`"
 OUTPUT_DIR="report"
 OUTPUT_CODE_DIR="_code_"


### PR DESCRIPTION
along with some whitespaces removal.